### PR TITLE
Use file-scoped namespaces. Use var keyword. Remove unnecessary comments.

### DIFF
--- a/csharp-basic-topics/TaskCompletedTaskFromResultVsReturnInCSharp/TaskCompletedVsTaskFromResultVsReturnInCSharp/ReturnClass.cs
+++ b/csharp-basic-topics/TaskCompletedTaskFromResultVsReturnInCSharp/TaskCompletedVsTaskFromResultVsReturnInCSharp/ReturnClass.cs
@@ -1,15 +1,13 @@
-﻿namespace TaskCompletedVsTaskFromResultVsReturnInCSharp
+﻿namespace TaskCompletedVsTaskFromResultVsReturnInCSharp;
+
+public class ReturnClass
 {
-    public class ReturnClass
+    public async Task<int> UseReturnMethodAsync()
     {
-        public async Task<int> UseReturnMethodAsync()
-        {
-            Console.WriteLine($"I am in {nameof(UseReturnMethodAsync)} method. About to perform some asynchronous work");
+        Console.WriteLine($"I am in {nameof(UseReturnMethodAsync)} method. About to perform some asynchronous work");
 
-            await Task.Delay(1000);
+        await Task.Delay(1000);
 
-            // Return a result
-            return 20;
-        }
+        return 20;
     }
 }

--- a/csharp-basic-topics/TaskCompletedTaskFromResultVsReturnInCSharp/TaskCompletedVsTaskFromResultVsReturnInCSharp/TaskCompletedClass.cs
+++ b/csharp-basic-topics/TaskCompletedTaskFromResultVsReturnInCSharp/TaskCompletedVsTaskFromResultVsReturnInCSharp/TaskCompletedClass.cs
@@ -1,13 +1,11 @@
-﻿namespace TaskCompletedVsTaskFromResultVsReturnInCSharp
-{
-    public class TaskCompletedClass
-    {
-        public Task UseTaskCompletedMethodAsync()
-        {
-            Console.WriteLine($"I am in {nameof(UseTaskCompletedMethodAsync)} method. Not performing any asynchronous work.");
+﻿namespace TaskCompletedVsTaskFromResultVsReturnInCSharp;
 
-            // Return a completed task
-            return Task.CompletedTask;
-        }
+public class TaskCompletedClass
+{
+    public Task UseTaskCompletedMethodAsync()
+    {
+        Console.WriteLine($"I am in {nameof(UseTaskCompletedMethodAsync)} method. Not performing any asynchronous work.");
+
+        return Task.CompletedTask;
     }
 }

--- a/csharp-basic-topics/TaskCompletedTaskFromResultVsReturnInCSharp/TaskCompletedVsTaskFromResultVsReturnInCSharp/TaskFromResultClass.cs
+++ b/csharp-basic-topics/TaskCompletedTaskFromResultVsReturnInCSharp/TaskCompletedVsTaskFromResultVsReturnInCSharp/TaskFromResultClass.cs
@@ -1,15 +1,13 @@
-﻿namespace TaskCompletedVsTaskFromResultVsReturnInCSharp
+﻿namespace TaskCompletedVsTaskFromResultVsReturnInCSharp;
+
+public class TaskFromResultClass
 {
-    public class TaskFromResultClass
+    public async Task<string> UseTaskFromResultMethodAsync()
     {
-        public async Task<string> UseTaskFromResultMethodAsync()
-        {
-            Console.WriteLine($"I am in {nameof(UseTaskFromResultMethodAsync)} method. Not performing any asynchronous work but returning a result.");
+        Console.WriteLine($"I am in {nameof(UseTaskFromResultMethodAsync)} method. Not performing any asynchronous work but returning a result.");
 
-            string message = "Hello, world!";
+        var message = "Hello, world!";
 
-            // Return a completed Task with a result
-            return await Task.FromResult(message);
-        }
+        return await Task.FromResult(message);
     }
 }

--- a/csharp-basic-topics/TaskCompletedTaskFromResultVsReturnInCSharp/Tests/TaskCompletedClassVsTaskFromResultClassVsReturnClassTests.cs
+++ b/csharp-basic-topics/TaskCompletedTaskFromResultVsReturnInCSharp/Tests/TaskCompletedClassVsTaskFromResultClassVsReturnClassTests.cs
@@ -1,36 +1,35 @@
-namespace TaskCompletedVsTaskFromResultVsReturnInCSharpTests
+namespace TaskCompletedVsTaskFromResultVsReturnInCSharpTests;
+
+public class TaskCompletedClassVsTaskFromResultClassVsReturnClassTests
 {
-    public class TaskCompletedClassVsTaskFromResultClassVsReturnClassTests
+    [Fact]
+    public void WhenCallingUseTaskCompletedMethodAsync_ThenUseTaskCompleted()
     {
-        [Fact]
-        public void WhenCallingUseTaskCompletedMethodAsync_ThenUseTaskCompleted()
-        {
-            TaskCompletedClass taskCompletedClass = new TaskCompletedClass();
+        var taskCompletedClass = new TaskCompletedClass();
 
-            var result = taskCompletedClass.UseTaskCompletedMethodAsync();
+        var result = taskCompletedClass.UseTaskCompletedMethodAsync();
 
-            Assert.True(result.IsCompletedSuccessfully);
-        }
+        Assert.True(result.IsCompletedSuccessfully);
+    }
 
-        [Fact]
-        public async Task WhenCallingUseTaskFromResultMethodAsync_ThenUseFromResult()
-        {
-            TaskFromResultClass taskFromResultClass = new TaskFromResultClass();
+    [Fact]
+    public async Task WhenCallingUseTaskFromResultMethodAsync_ThenUseFromResult()
+    {
+        var taskFromResultClass = new TaskFromResultClass();
 
-            var result =  taskFromResultClass.UseTaskFromResultMethodAsync();
-            string message = await result;
+        var result =  taskFromResultClass.UseTaskFromResultMethodAsync();
+        var message = await result;
 
-            Assert.Equal("Hello, world!", message);
-        }
+        Assert.Equal("Hello, world!", message);
+    }
 
-        [Fact]
-        public async Task WhenCallingUseReturnMethodAsync_ThenUseReturn()
-        {
-            ReturnClass returnClass = new ReturnClass();
+    [Fact]
+    public async Task WhenCallingUseReturnMethodAsync_ThenUseReturn()
+    {
+        var returnClass = new ReturnClass();
 
-            var result = await returnClass.UseReturnMethodAsync();
+        var result = await returnClass.UseReturnMethodAsync();
 
-            Assert.Equal(20, result);
-        }
+        Assert.Equal(20, result);
     }
 }


### PR DESCRIPTION
Use file-scoped namespaces. Use var keyword in place of specific types. Remove comments that the codes already clearly show.