### PR TITLE
Add fullstop to a line of code for consistency. Move await to the same line where UseTaskFromResultAsync method is called.

### DIFF
--- a/csharp-basic-topics/TaskCompletedTaskFromResultVsReturnInCSharp/TaskCompletedVsTaskFromResultVsReturnInCSharp/ReturnHandler.cs
+++ b/csharp-basic-topics/TaskCompletedTaskFromResultVsReturnInCSharp/TaskCompletedVsTaskFromResultVsReturnInCSharp/ReturnHandler.cs
@@ -4,7 +4,7 @@ public class ReturnHandler
 {
     public async Task<int> UseReturnAsync()
     {
-        Console.WriteLine("About to perform some asynchronous work");
+        Console.WriteLine("About to perform some asynchronous work.");
 
         await Task.Delay(1000);
 

--- a/csharp-basic-topics/TaskCompletedTaskFromResultVsReturnInCSharp/Tests/TaskCompletedVsTaskFromResultVsReturnTests.cs
+++ b/csharp-basic-topics/TaskCompletedTaskFromResultVsReturnInCSharp/Tests/TaskCompletedVsTaskFromResultVsReturnTests.cs
@@ -17,8 +17,7 @@ public class TaskCompletedVsTaskFromResultVsReturnTests
     {
         var taskFromResultClass = new TaskFromResultHandler();
 
-        var result =  taskFromResultClass.UseTaskFromResultAsync();
-        var message = await result;
+        var message =  await taskFromResultClass.UseTaskFromResultAsync();
 
         Assert.Equal("Hello, world!", message);
     }


### PR DESCRIPTION
Add fullstop to a line of code for consistency. Move await to the same line where UseTaskFromResultAsync method is called.