### PR TITLE
Add a method that uses ReadOnlySpan to truncate a string. Improve Benchmark setup. Refactor some methods.

### DIFF
--- a/strings-csharp/StringTruncationInCSharp/StringTruncationInCSharp/StringExtensions.cs
+++ b/strings-csharp/StringTruncationInCSharp/StringTruncationInCSharp/StringExtensions.cs
@@ -4,6 +4,15 @@
     {
         public static string TruncateString(this string originalString, int maxLength)
         {
+            if (maxLength <= 0)
+            {
+                return string.Empty;
+            }
+            else if (maxLength >= originalString.Length)
+            {
+                return originalString;
+            }
+
             var truncatedString = originalString.Substring(0, maxLength);
 
             return truncatedString;

--- a/strings-csharp/StringTruncationInCSharp/StringTruncationInCSharp/StringHelper.cs
+++ b/strings-csharp/StringTruncationInCSharp/StringTruncationInCSharp/StringHelper.cs
@@ -5,99 +5,111 @@ namespace StringTruncationInCSharp
 {
     public class StringHelper
     {
-public string TruncateStringUsingSubstring(string originalString, int maxLength)
-{
-    if (maxLength <= 0)
-    {
-        return string.Empty;
-    }
-    else if (maxLength >= originalString.Length)
-    {
-        return originalString;
-    }
+        public string TruncateStringUsingSubstring(string originalString, int maxLength)
+        {
+            if (maxLength <= 0)
+            {
+                return string.Empty;
+            }
+            else if (maxLength >= originalString.Length)
+            {
+                return originalString;
+            }
 
-    var truncatedString = originalString.Substring(0, maxLength);
+            var truncatedString = originalString.Substring(0, maxLength);
 
-    return truncatedString;
-}
-        
-public string TruncateStringUsingRemove(string originalString, int maxLength)
-{
-    if (maxLength <= 0)
-    {
-        return string.Empty;
-    }
-    else if (maxLength >= originalString.Length)
-    {
-        return originalString;
-    }
+            return truncatedString;
+        }
 
-    if (originalString.Length > maxLength)
-    {
-        return originalString.Remove(maxLength);
-    }
+        public string TruncateStringUsingRemove(string originalString, int maxLength)
+        {
+            if (maxLength <= 0)
+            {
+                return string.Empty;
+            }
+            else if (originalString.Length > maxLength)
+            {
+                return originalString.Remove(maxLength);
+            }
 
-    return originalString;
-}
-        
-public string TruncateStringUsingForLoopWithStringBuilder(string originalString, int maxLength)
-{
-    if (maxLength <= 0)
-    {
-        return string.Empty;
-    }
-    else if (maxLength >= originalString.Length)
-    {
-        return originalString;
-    }
+            return originalString;
+        }
 
-    var length = Math.Min(maxLength, originalString.Length);
-    var truncatedStringBuilder = new StringBuilder(length);
+        public string TruncateStringUsingForLoopWithStringBuilder(string originalString, int maxLength)
+        {
+            if (maxLength <= 0)
+            {
+                return string.Empty;
+            }
+            else if (maxLength >= originalString.Length)
+            {
+                return originalString;
+            }
 
-    for (int i = 0; i < length; i++)
-    {
-        truncatedStringBuilder.Append(originalString[i]);
-    }
+            var length = Math.Min(maxLength, originalString.Length);
+            var truncatedStringBuilder = new StringBuilder(length);
 
-    var truncatedString = truncatedStringBuilder.ToString();
+            for (int i = 0; i < length; i++)
+            {
+                truncatedStringBuilder.Append(originalString[i]);
+            }
 
-    return truncatedString;
-}
-        
+            var truncatedString = truncatedStringBuilder.ToString();
+
+            return truncatedString;
+        }
+
         public string TruncateStringUsingLINQ(string originalString, int maxLength)
         {
             var truncatedString = new string(originalString.Take(maxLength).ToArray());
 
             return truncatedString;
         }
-        
-public string TruncateStringUsingForLoop(string originalString, int maxLength)
-{
-    var truncatedString = string.Empty;
-    int length = Math.Min(maxLength, originalString.Length);
 
-    for (int i = 0; i < length; i++)
-    {
-        truncatedString += originalString[i];
-    }
+        public string TruncateStringUsingForLoop(string originalString, int maxLength)
+        {
+            var truncatedString = string.Empty;
+            int length = Math.Min(maxLength, originalString.Length);
 
-    return truncatedString;
-}
-        
-public string TruncateStringUsingRegularExpressions(string originalString, int maxLength)
-{
-    if (maxLength <= 0)
-    {
-        return string.Empty;
-    }
-    else if (maxLength >= originalString.Length)
-    {
-        return originalString;
-    }
+            for (int i = 0; i < length; i++)
+            {
+                truncatedString += originalString[i];
+            }
 
-    var truncatedString = Regex.Replace(originalString, $"^(.{{0,{maxLength}}}).*$", "$1");
+            return truncatedString;
+        }
 
-    return truncatedString;
-}
+        public string TruncateStringUsingRegularExpressions(string originalString, int maxLength)
+        {
+            if (maxLength <= 0)
+            {
+                return string.Empty;
+            }
+            else if (maxLength >= originalString.Length)
+            {
+                return originalString;
+            }
+
+            var truncatedString = Regex.Replace(originalString, $"^(.{{0,{maxLength}}}).*$", "$1");
+
+            return truncatedString;
+        }
+
+        public string TruncateStringUsingSpan(string originalString, int maxLength)
+        {
+            if (string.IsNullOrEmpty(originalString) || maxLength <= 0)
+            {
+                return string.Empty;
+            }
+
+            ReadOnlySpan<char> originalStringAsSpan = originalString.AsSpan();
+            if (maxLength >= originalStringAsSpan.Length)
+            {
+                return new string(originalStringAsSpan);
+            }
+
+            return new string(originalStringAsSpan.Slice(0, maxLength));
+        }
+
     }
 }

--- a/strings-csharp/StringTruncationInCSharp/StringTruncationInCSharp/StringHelperBenchmark.cs
+++ b/strings-csharp/StringTruncationInCSharp/StringTruncationInCSharp/StringHelperBenchmark.cs
@@ -3,46 +3,82 @@
 namespace StringTruncationInCSharp
 {
     [MemoryDiagnoser]
+    [Orderer(BenchmarkDotNet.Order.SummaryOrderPolicy.FastestToSlowest)]
+    [RankColumn]
     public class StringHelperBenchmark
     {
-        private readonly int _maxLength = 10;
-        private readonly string _originalString = "This is a long string.";
+        private string _originalString = "This is a long string.";
         private static readonly StringHelper _stringHelper = new StringHelper();
+
+        [Params(0.01, 0.10, 0.50, 0.95)]
+        public double MaxLengthPercentage;
+    
+        [GlobalSetup]
+        public void Setup()
+        {
+            _originalString = GetDummyStringToTestBenchmark();
+        }
+
 
         [Benchmark]
         public void TruncateStringUsingSubstring()
         {
-            _stringHelper.TruncateStringUsingSubstring(_originalString, _maxLength);
+            int maxLength = (int)(_originalString.Length * MaxLengthPercentage);
+
+            _stringHelper.TruncateStringUsingSubstring(_originalString, maxLength);
         }
 
         [Benchmark]
         public void TruncateStringUsingForLoop()
         {
-            _stringHelper.TruncateStringUsingForLoop(_originalString, _maxLength);
+            int maxLength = (int)(_originalString.Length * MaxLengthPercentage);
+
+            _stringHelper.TruncateStringUsingForLoop(_originalString, maxLength);
         }
 
         [Benchmark]
         public void TruncateStringUsingForLoopWithStringBuilder()
         {
-            _stringHelper.TruncateStringUsingForLoopWithStringBuilder(_originalString, _maxLength);
+            int maxLength = (int)(_originalString.Length * MaxLengthPercentage);
+            _stringHelper.TruncateStringUsingForLoopWithStringBuilder(_originalString, maxLength);
         }
 
         [Benchmark]
         public void TruncateStringUsingRegularExpressions()
         {
-            _stringHelper.TruncateStringUsingRegularExpressions(_originalString, _maxLength);
+            int maxLength = (int)(_originalString.Length * MaxLengthPercentage);
+            _stringHelper.TruncateStringUsingRegularExpressions(_originalString, maxLength);
         }
 
         [Benchmark]
         public void TruncateStringUsingRemove()
         {
-            _stringHelper.TruncateStringUsingRemove(_originalString, _maxLength);
+            int maxLength = (int)(_originalString.Length * MaxLengthPercentage);
+
+            _stringHelper.TruncateStringUsingRemove(_originalString, maxLength);
         }
 
         [Benchmark]
         public void TruncateStringUsingLINQ()
         {
-            _stringHelper.TruncateStringUsingLINQ(_originalString, _maxLength);
+            int maxLength = (int)(_originalString.Length * MaxLengthPercentage);
+
+            _stringHelper.TruncateStringUsingLINQ(_originalString, maxLength);
+        }
+
+        [Benchmark]
+        public void TruncateStringUsingSpan()
+        {
+            int maxLength = (int)(_originalString.Length * MaxLengthPercentage);
+
+            _stringHelper.TruncateStringUsingSpan(_originalString, maxLength);
+        }
+
+        private string GetDummyStringToTestBenchmark()
+        {
+            var dummyText = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. N";
+
+            return dummyText;
         }
     }
 }

--- a/strings-csharp/StringTruncationInCSharp/StringTruncationInCSharpTests/StringTruncationUnitTest.cs
+++ b/strings-csharp/StringTruncationInCSharp/StringTruncationInCSharpTests/StringTruncationUnitTest.cs
@@ -258,5 +258,47 @@ namespace StringTruncationInCSharpTests
 
             Assert.Equal(string.Empty, truncatedString);
         }
+
+
+
+        [Fact]
+        public void WhenTruncatingAString_ThenUseSpanToTruncateTheString()
+        {
+            var truncatedString = _stringHelper.TruncateStringUsingSpan(_originalString, _maxLength);
+
+            Assert.Equal("This is a ", truncatedString);
+        }
+
+        [Fact]
+        public void GivenALengthEqualToTheStringLength_WhenTruncatingAString_ThenUseSpanMethodWithoutTruncatingTheString()
+        {
+            var truncatedString = _stringHelper.TruncateStringUsingSpan(_originalString, _maxLengthEqualToGivenStringLength);
+
+            Assert.Equal("This is a long string.", truncatedString);
+        }
+
+        [Fact]
+        public void GivenALengthGreaterThanTheStringLength_WhenTruncatingAString_ThenUseSpanMethodWithoutTruncatingTheString()
+        {
+            var truncatedString = _stringHelper.TruncateStringUsingSpan(_originalString, _maxLengthGreaterThanGivenStringLength);
+
+            Assert.Equal("This is a long string.", truncatedString);
+        }
+
+        [Fact]
+        public void GivenAZeroLength_WhenTruncatingAString_ThenUseSpanMethodAndReturnAnEmptyString()
+        {
+            var truncatedString = _stringHelper.TruncateStringUsingSpan(_originalString, _maxLengthEqualToZero);
+
+            Assert.Equal(string.Empty, truncatedString);
+        }
+
+        [Fact]
+        public void GivenANonPositiveLength_WhenTruncatingAString_ThenUseSpanMethodAndReturnAnEmptyString()
+        {
+            var truncatedString = _stringHelper.TruncateStringUsingSpan(_originalString, _maxLengthLessThanZero);
+
+            Assert.Equal(string.Empty, truncatedString);
+        }
     }
 }


### PR DESCRIPTION
Add a method that uses ReadOnlySpan to truncate a string. Increase the length of the test string used in the Benchmark setup. Add rank order and params to Benchmark. Refactor TruncateStringUsingRemove() method.